### PR TITLE
fixed add_edge function, added test_example.py

### DIFF
--- a/GCL/augmentors/functional.py
+++ b/GCL/augmentors/functional.py
@@ -302,7 +302,7 @@ def add_edge(edge_index: torch.Tensor, ratio: float) -> torch.Tensor:
     new_edge_index = torch.randint(0, num_nodes - 1, size=(2, num_add)).to(edge_index.device)
     edge_index = torch.cat([edge_index, new_edge_index], dim=1)
 
-    edge_index = sort_edge_index(edge_index)[0]
+    edge_index = sort_edge_index(edge_index)
 
     return coalesce_edge_index(edge_index)[0]
 

--- a/test_example.py
+++ b/test_example.py
@@ -1,0 +1,7 @@
+import torch
+import GCL.augmentors as A
+aug=A.Compose([A.EdgeAdding(pe=0.4)])
+edge_index=torch.randint(0,11,(2,10))
+x=torch.randn((10,128))
+auged=aug(x,edge_index)
+auged_x,auged_edge_index,_=auged


### PR DESCRIPTION
Thanks for opensourcing such good contribution.
I wrote a test code like this:
```python
import torch
import GCL.augmentors as A
aug=A.Compose([A.EdgeAdding(pe=0.4),A.FeatureDropout(pf=0.5)])
edge_index=torch.randint(0,10,(2,10)) 
x=torch.randn((10,128))
auged=aug(x,edge_index)
print(auged)
```
and it got this: 
```
num_edges = edge_index.size()[1]
IndexError: tuple index out of range
```

After I checked the code in ``add_edge`` function in ``functional.py``, there could be a little problem with these piece of code:
```python
def add_edge(edge_index: torch.Tensor, ratio: float) -> torch.Tensor:
    num_edges = edge_index.size()[1]
    num_nodes = edge_index.max().item() + 1
    num_add = int(num_edges * ratio)

    new_edge_index = torch.randint(0, num_nodes - 1, size=(2, num_add)).to(edge_index.device)
    edge_index = torch.cat([edge_index, new_edge_index], dim=1)
    
    # here could be wrongly written. [0] might be removed.
    edge_index = sort_edge_index(edge_index)[0]

    return coalesce_edge_index(edge_index)[0]

```
If we keep ``[0]`` in the code, only the first array of edge index would be extracted, and it's not what we wanted.

Don't know if this is an issue here?