### PR TITLE
Add DGL implementation for most augmentors

### DIFF
--- a/GCL/augmentor/augmentor.py
+++ b/GCL/augmentor/augmentor.py
@@ -8,7 +8,6 @@ from torch_geometric.data import Data as PyGGraph
 
 
 class Augmentor(ABC):
-    """Base class for graph augmentor."""
     def __init__(self):
         pass
 

--- a/GCL/augmentor/edge_adding.py
+++ b/GCL/augmentor/edge_adding.py
@@ -1,5 +1,6 @@
 from GCL.augmentor.augmentor import PyGGraph, DGLGraph, Augmentor
 from GCL.augmentor.functional import add_edge
+import GCL.augmentor.functional_dgl as F_dgl
 
 
 class EdgeAdding(Augmentor):
@@ -13,4 +14,4 @@ class EdgeAdding(Augmentor):
         return g
 
     def dgl_augment(self, g: DGLGraph):
-        raise NotImplementedError
+        return F_dgl.add_edge(g, self.pe)

--- a/GCL/augmentor/edge_attr_masking.py
+++ b/GCL/augmentor/edge_attr_masking.py
@@ -14,4 +14,11 @@ class EdgeAttrMasking(Augmentor):
         return g
 
     def dgl_augment(self, g: DGLGraph):
-        raise NotImplementedError
+        g = g.clone()
+
+        edata_keys = list(g.edata.keys())
+
+        for edata_key in edata_keys:
+            g.edata[edata_key] = drop_feature(g.edata[edata_key], self.pf)
+
+        return g

--- a/GCL/augmentor/edge_removing.py
+++ b/GCL/augmentor/edge_removing.py
@@ -1,5 +1,6 @@
 from GCL.augmentor.augmentor import PyGGraph, DGLGraph, Augmentor
 from GCL.augmentor.functional import dropout_adj
+import GCL.augmentor.functional_dgl as F_dgl
 
 
 class EdgeRemoving(Augmentor):
@@ -15,4 +16,4 @@ class EdgeRemoving(Augmentor):
         return g
 
     def dgl_augment(self, g: DGLGraph):
-        raise NotImplementedError
+        return F_dgl.drop_edge(g, drop_prob=self.pe)

--- a/GCL/augmentor/feature_dropout.py
+++ b/GCL/augmentor/feature_dropout.py
@@ -13,4 +13,8 @@ class FeatureDropout(Augmentor):
         return g
 
     def dgl_augment(self, g: DGLGraph):
-        raise NotImplementedError
+        g = g.clone()
+        new_x = dropout_feature(g.ndata['x'], self.pf)
+        g.ndata['x'] = new_x
+
+        return g

--- a/GCL/augmentor/feature_masking.py
+++ b/GCL/augmentor/feature_masking.py
@@ -13,4 +13,8 @@ class FeatureMasking(Augmentor):
         return g
 
     def dgl_augment(self, g: DGLGraph):
-        raise NotImplementedError
+        g = g.clone()
+        new_x = drop_feature(g.ndata['x'], self.pf)
+        g.ndata['x'] = new_x
+
+        return g

--- a/GCL/augmentor/functional_dgl.py
+++ b/GCL/augmentor/functional_dgl.py
@@ -1,0 +1,16 @@
+import math
+import torch
+import dgl
+
+
+def add_edge(g: dgl.DGLGraph, ratio: float) -> dgl.DGLGraph:
+    g = g.clone()
+    num_edges = g.num_edges()
+    num_nodes = g.num_nodes()
+
+    num_add = math.floor(num_edges * ratio)
+    added_edge_index = torch.randint(0, num_nodes - 1, size=(2, num_add)).to(g.device)
+    u_new, v_new = added_edge_index
+
+    g.add_edges(u_new, v_new)
+    return dgl.to_simple(g)

--- a/GCL/augmentor/functional_dgl.py
+++ b/GCL/augmentor/functional_dgl.py
@@ -28,3 +28,15 @@ def drop_edge(g: dgl.DGLGraph, drop_prob: float) -> dgl.DGLGraph:
     g.remove_edges(eids=remove_eids)
 
     return g
+
+
+def drop_node(g: dgl.DGLGraph, drop_prob: float) -> dgl.DGLGraph:
+    g = g.clone()
+    mask = torch.zeros((g.num_nodes(),), dtype=torch.float32).to(g.device)
+    torch.fill_(mask, drop_prob)
+    mask = torch.bernoulli(mask)
+
+    remove_nids = torch.nonzero(mask).view(-1)
+    g.remove_edges(remove_nids)
+
+    return g

--- a/GCL/augmentor/functional_dgl.py
+++ b/GCL/augmentor/functional_dgl.py
@@ -14,3 +14,17 @@ def add_edge(g: dgl.DGLGraph, ratio: float) -> dgl.DGLGraph:
 
     g.add_edges(u_new, v_new)
     return dgl.to_simple(g)
+
+
+def drop_edge(g: dgl.DGLGraph, drop_prob: float) -> dgl.DGLGraph:
+    assert 0 <= drop_prob <= 1, 'Dropping probability should be between 0 and 1.'
+    g = g.clone()
+
+    mask = torch.zeros((g.num_edges(),), dtype=torch.float32).to(g.device)
+    torch.fill_(mask, drop_prob)
+    mask = torch.bernoulli(mask).to(torch.bool)
+
+    remove_eids = g.edges(form='eid')[mask]
+    g.remove_edges(eids=remove_eids)
+
+    return g

--- a/GCL/augmentor/node_dropping.py
+++ b/GCL/augmentor/node_dropping.py
@@ -1,5 +1,6 @@
 from GCL.augmentor.augmentor import PyGGraph, DGLGraph, Augmentor
 from GCL.augmentor.functional import drop_node
+import GCL.augmentor.functional_dgl as F_dgl
 
 
 class NodeDropping(Augmentor):
@@ -9,10 +10,10 @@ class NodeDropping(Augmentor):
 
     def pyg_augment(self, g: PyGGraph):
         g = g.clone()
-        edge_index, edge_weights = drop_node(g.edge_index, g.edge_weights, keep_prob=1. - self.pn)
+        edge_index, edge_weights = drop_node(g.edge_index, g.edge_attr, keep_prob=1. - self.pn)
         g.edge_index = edge_index
         g.edge_attr = edge_weights
         return g
 
     def dgl_augment(self, g: DGLGraph):
-        raise NotImplementedError
+        return F_dgl.drop_node(g, self.pn)

--- a/GCL/augmentor/node_shuffling.py
+++ b/GCL/augmentor/node_shuffling.py
@@ -12,4 +12,6 @@ class NodeShuffling(Augmentor):
         return g
 
     def dgl_augment(self, g: DGLGraph):
-        raise NotImplementedError
+        g = g.clone()
+        g.ndata['x'] = permute(g.ndata['x'])
+        return g

--- a/test/augmentor/test_augmentor.py
+++ b/test/augmentor/test_augmentor.py
@@ -5,6 +5,7 @@ import torch_geometric.transforms as T
 from functools import partial
 from torch_geometric.data import Data
 from GCL.augmentor import PyGAugmentor, DGLAugmentor, Compose
+from GCL.augmentor import EdgeAdding
 
 
 def test_pygaugmentor():
@@ -38,3 +39,22 @@ def test_composing_augmentor():
     comp_aug = Compose([aug1, aug2])
     data = comp_aug(data)
     assert data.x.tolist() == [[1.0, 2.0], [1.0, 2.0], [1.0, 2.0]]
+
+
+def test_edge_adding():
+    aug = EdgeAdding(pe=0.8)
+    edge_index = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
+    data = Data(edge_index=edge_index, num_nodes=3)
+    aug_data = aug(data)
+    assert aug_data.edge_index.shape[0] == 2
+    assert aug_data.edge_index.shape[1] >= data.edge_index.shape[1]
+
+
+def test_edge_adding_dgl():
+    aug = EdgeAdding(pe=0.8)
+    edge_index = torch.tensor([[0, 1, 1, 2], [1, 0, 2, 1]])
+    u, v = edge_index
+    g: dgl.DGLGraph = dgl.graph((u, v), num_nodes=3)
+    aug_g = aug(g)
+
+    assert aug_g.num_edges() >= g.num_edges()

--- a/test/test_augmentor.py
+++ b/test/test_augmentor.py
@@ -8,7 +8,7 @@ from GCL.augmentor import PyGAugmentor, DGLAugmentor, Compose
 from GCL.augmentor import \
     EdgeAdding, EdgeRemoving, EdgeAttrMasking, \
     FeatureDropout, FeatureMasking, \
-    NodeDropping
+    NodeDropping, NodeShuffling
 
 import testing_utils
 
@@ -130,3 +130,19 @@ def test_node_dropping_dgl():
     aug_g = aug(g)
 
     assert aug_g.num_nodes() <= g.num_nodes()
+
+
+def test_node_shuffling():
+    aug = NodeShuffling()
+    g = testing_utils.random_pyg_graph(num_nodes=100, num_edges=1000, feature_dim=128)
+    aug_g = aug(g)
+
+    assert (g.x.mean().item() - aug_g.x.mean().item()) < 1e-8
+
+
+def test_node_shuffling_dgl():
+    aug = NodeShuffling()
+    g = testing_utils.random_dgl_graph(num_nodes=100, num_edges=1000, feature_dim=128)
+    aug_g = aug(g)
+
+    assert (g.ndata['x'].mean().item() - aug_g.ndata['x'].mean().item()) < 1e-8

--- a/test/test_augmentor.py
+++ b/test/test_augmentor.py
@@ -5,7 +5,9 @@ import torch_geometric.transforms as T
 from functools import partial
 from torch_geometric.data import Data
 from GCL.augmentor import PyGAugmentor, DGLAugmentor, Compose
-from GCL.augmentor import EdgeAdding
+from GCL.augmentor import EdgeAdding, EdgeRemoving
+
+import testing_utils
 
 
 def test_pygaugmentor():
@@ -58,3 +60,18 @@ def test_edge_adding_dgl():
     aug_g = aug(g)
 
     assert aug_g.num_edges() >= g.num_edges()
+
+
+def test_edge_removing():
+    aug = EdgeRemoving(pe=0.5)
+    data = testing_utils.random_pyg_graph(num_nodes=3, num_edges=4)
+    aug_data = aug(data)
+    assert aug_data.edge_index.shape[0] == 2
+    assert aug_data.edge_index.shape[1] <= data.edge_index.shape[1]
+
+
+def test_edge_removing_dgl():
+    aug = EdgeRemoving(pe=0.5)
+    g = testing_utils.random_dgl_graph(num_nodes=3, num_edges=4)
+    aug_g = aug(g)
+    assert aug_g.num_edges() <= g.num_edges()

--- a/test/test_augmentor.py
+++ b/test/test_augmentor.py
@@ -5,7 +5,10 @@ import torch_geometric.transforms as T
 from functools import partial
 from torch_geometric.data import Data
 from GCL.augmentor import PyGAugmentor, DGLAugmentor, Compose
-from GCL.augmentor import EdgeAdding, EdgeRemoving, EdgeAttrMasking, FeatureDropout, FeatureMasking
+from GCL.augmentor import \
+    EdgeAdding, EdgeRemoving, EdgeAttrMasking, \
+    FeatureDropout, FeatureMasking, \
+    NodeDropping
 
 import testing_utils
 
@@ -111,3 +114,19 @@ def test_feature_masking_dgl():
 
     assert aug_g.ndata['x'].shape == g.ndata['x'].shape
     # assert aug_g.x.abs().mean().item() < g.x.abs().mean().item()
+
+
+def test_node_dropping():
+    aug = NodeDropping(pn=0.5)
+    g = testing_utils.random_pyg_graph(num_nodes=100, num_edges=500, feature_dim=32)
+    aug_g = aug(g)
+
+    assert aug_g.edge_index.max().item() + 1 <= g.edge_index.max().item() + 1
+
+
+def test_node_dropping_dgl():
+    aug = NodeDropping(pn=0.5)
+    g = testing_utils.random_dgl_graph(num_nodes=100, num_edges=500, feature_dim=32)
+    aug_g = aug(g)
+
+    assert aug_g.num_nodes() <= g.num_nodes()

--- a/test/test_augmentor.py
+++ b/test/test_augmentor.py
@@ -5,7 +5,7 @@ import torch_geometric.transforms as T
 from functools import partial
 from torch_geometric.data import Data
 from GCL.augmentor import PyGAugmentor, DGLAugmentor, Compose
-from GCL.augmentor import EdgeAdding, EdgeRemoving
+from GCL.augmentor import EdgeAdding, EdgeRemoving, EdgeAttrMasking, FeatureDropout, FeatureMasking
 
 import testing_utils
 
@@ -75,3 +75,39 @@ def test_edge_removing_dgl():
     g = testing_utils.random_dgl_graph(num_nodes=3, num_edges=4)
     aug_g = aug(g)
     assert aug_g.num_edges() <= g.num_edges()
+
+
+def test_feature_dropout():
+    aug = FeatureDropout(pf=0.5)
+    g = testing_utils.random_pyg_graph(num_nodes=3, num_edges=5, feature_dim=10)
+    aug_g = aug(g)
+
+    assert aug_g.x.shape == g.x.shape
+    # assert aug_g.x.abs().mean().item() < g.x.abs().mean().item()
+
+
+def test_feature_dropout_dgl():
+    aug = FeatureDropout(pf=0.5)
+    g = testing_utils.random_dgl_graph(num_nodes=3, num_edges=5, feature_dim=10)
+    aug_g = aug(g)
+
+    assert aug_g.ndata['x'].shape == g.ndata['x'].shape
+    # assert aug_g.x.abs().mean().item() < g.x.abs().mean().item()
+
+
+def test_feature_masking():
+    aug = FeatureMasking(pf=0.5)
+    g = testing_utils.random_pyg_graph(num_nodes=3, num_edges=5, feature_dim=10)
+    aug_g = aug(g)
+
+    assert aug_g.x.shape == g.x.shape
+    # assert aug_g.x.abs().mean().item() < g.x.abs().mean().item()
+
+
+def test_feature_masking_dgl():
+    aug = FeatureMasking(pf=0.5)
+    g = testing_utils.random_dgl_graph(num_nodes=3, num_edges=5, feature_dim=10)
+    aug_g = aug(g)
+
+    assert aug_g.ndata['x'].shape == g.ndata['x'].shape
+    # assert aug_g.x.abs().mean().item() < g.x.abs().mean().item()

--- a/test/testing_utils.py
+++ b/test/testing_utils.py
@@ -1,0 +1,25 @@
+import torch
+import dgl
+
+from torch_geometric.data import Data
+from torch_geometric.utils import sort_edge_index
+
+import GCL.augmentor.functional as F
+
+
+def random_pyg_graph(num_nodes: int, num_edges: int) -> Data:
+    edge_index = torch.randint(0, num_nodes - 1, size=(2, num_edges))
+    edge_index = sort_edge_index(edge_index)[0]
+    edge_index = F.coalesce_edge_index(edge_index)[0]
+
+    return Data(edge_index=edge_index, num_nodes=num_nodes)
+
+
+def random_dgl_graph(num_nodes: int, num_edges: int) -> dgl.DGLGraph:
+    edge_index = torch.randint(0, num_nodes - 1, size=(2, num_edges))
+    u, v = edge_index
+    g = dgl.graph((u, v))
+    g = dgl.to_simple(g)
+
+    return g
+

--- a/test/testing_utils.py
+++ b/test/testing_utils.py
@@ -7,19 +7,24 @@ from torch_geometric.utils import sort_edge_index
 import GCL.augmentor.functional as F
 
 
-def random_pyg_graph(num_nodes: int, num_edges: int) -> Data:
+def random_pyg_graph(num_nodes: int, num_edges: int, feature_dim: int = 256) -> Data:
     edge_index = torch.randint(0, num_nodes - 1, size=(2, num_edges))
     edge_index = sort_edge_index(edge_index)[0]
     edge_index = F.coalesce_edge_index(edge_index)[0]
 
-    return Data(edge_index=edge_index, num_nodes=num_nodes)
+    x = torch.randn((num_nodes, feature_dim), dtype=torch.float32)
+
+    return Data(edge_index=edge_index, num_nodes=num_nodes, x=x)
 
 
-def random_dgl_graph(num_nodes: int, num_edges: int) -> dgl.DGLGraph:
+def random_dgl_graph(num_nodes: int, num_edges: int, feature_dim: int = 256) -> dgl.DGLGraph:
     edge_index = torch.randint(0, num_nodes - 1, size=(2, num_edges))
     u, v = edge_index
     g = dgl.graph((u, v))
     g = dgl.to_simple(g)
+
+    x = torch.randn((g.num_nodes(), feature_dim), dtype=torch.float32)
+    g.ndata['x'] = x
 
     return g
 


### PR DESCRIPTION
This PR adds the DGL implementation for most augmentors. It also adds tests for existing augmentors.

Augmentors that do not have a DGL implementation (yet):
- `MarkovDiffusion`
- `PPRDiffusion`
- `RWSampling`

The DGL implementation for above augmentors can be added after this DGL PR (https://github.com/dmlc/dgl/pull/3668/files) that adds a variety of graph augmentation operators. Also, the existing DGL implementation could be updated after this PR is merged into DGL.